### PR TITLE
[v2.2.2] fix: Modify Logger to return void for disallowed messages

### DIFF
--- a/src/Libraries/Logger.php
+++ b/src/Libraries/Logger.php
@@ -79,7 +79,7 @@ class Logger extends LogLogger
 
         // skip syloer jika di pesan terdapat kalimat 'disallowed characters'
         if (is_string($message) && str_contains($message, 'disallowed characters')) {
-            return true;
+            return;
         }
 
         // kirim notif ke Telegram


### PR DESCRIPTION
Change return value to void when message contains disallowed characters.